### PR TITLE
Handle missing Astra DB configuration gracefully

### DIFF
--- a/app/api/analytics/route.ts
+++ b/app/api/analytics/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getTradeCollection } from '@/lib/astra';
+import { ASTRA_DB_MISSING_ENV_MESSAGE, getTradeCollection } from '@/lib/astra';
 import { calculateAnalytics } from '@/lib/analytics';
 import type { TradeEntry } from '@/types/trade';
 
@@ -18,6 +18,12 @@ export async function GET(req: Request) {
     }
 
     const collection = await getTradeCollection();
+    if (!collection) {
+      return NextResponse.json(
+        { error: ASTRA_DB_MISSING_ENV_MESSAGE },
+        { status: 500 },
+      );
+    }
     const cursor = await collection.find(filter, {
       limit: Number.isNaN(limit) ? 500 : limit,
       sort: { createdAt: -1 },

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { CHAT_MODEL, EMBEDDING_MODEL, openai } from '@/lib/openai';
-import { getTradeCollection } from '@/lib/astra';
+import { ASTRA_DB_MISSING_ENV_MESSAGE, getTradeCollection } from '@/lib/astra';
 import type { SearchFilters, TradeEntry } from '@/types/trade';
 import { buildEmbeddingText } from '@/lib/trade-helpers';
 
@@ -43,6 +43,13 @@ export async function POST(req: Request) {
     }
 
     const collection = await getTradeCollection();
+    if (!collection) {
+      return NextResponse.json(
+        { error: ASTRA_DB_MISSING_ENV_MESSAGE },
+        { status: 500 },
+      );
+    }
+
     const { data } = await openai.embeddings.create({
       input: body.query,
       model: EMBEDDING_MODEL,

--- a/app/api/trades/[tradeId]/route.ts
+++ b/app/api/trades/[tradeId]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { Params } from 'next/dist/shared/lib/router/utils/route-matcher';
-import { getTradeCollection } from '@/lib/astra';
+import { ASTRA_DB_MISSING_ENV_MESSAGE, getTradeCollection } from '@/lib/astra';
 import { CHAT_MODEL, EMBEDDING_MODEL, openai } from '@/lib/openai';
 import type { TradeAttachment, TradeEntry } from '@/types/trade';
 import {
@@ -30,6 +30,12 @@ const embed = async (trade: TradeEntry) => {
 export async function GET(_req: Request, context: { params: Params }) {
   try {
     const collection = await getTradeCollection();
+    if (!collection) {
+      return NextResponse.json(
+        { error: ASTRA_DB_MISSING_ENV_MESSAGE },
+        { status: 500 },
+      );
+    }
     const document = await collection.findOne({ document_id: context.params.tradeId });
 
     if (!document) {
@@ -63,6 +69,12 @@ export async function PUT(req: Request, context: { params: Params }) {
     } = body;
 
     const collection = await getTradeCollection();
+    if (!collection) {
+      return NextResponse.json(
+        { error: ASTRA_DB_MISSING_ENV_MESSAGE },
+        { status: 500 },
+      );
+    }
     const existingDocument = await collection.findOne({ document_id: context.params.tradeId });
 
     if (!existingDocument) {
@@ -167,6 +179,12 @@ export async function PUT(req: Request, context: { params: Params }) {
 export async function DELETE(_req: Request, context: { params: Params }) {
   try {
     const collection = await getTradeCollection();
+    if (!collection) {
+      return NextResponse.json(
+        { error: ASTRA_DB_MISSING_ENV_MESSAGE },
+        { status: 500 },
+      );
+    }
     await collection.deleteOne({ document_id: context.params.tradeId });
     return NextResponse.json({ ok: true });
   } catch (error) {

--- a/app/api/trades/route.ts
+++ b/app/api/trades/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { CHAT_MODEL, EMBEDDING_MODEL, openai } from '@/lib/openai';
-import { getTradeCollection } from '@/lib/astra';
+import { ASTRA_DB_MISSING_ENV_MESSAGE, getTradeCollection } from '@/lib/astra';
 import {
   TradeAttachment,
   TradeDocument,
@@ -65,6 +65,12 @@ export async function GET(req: Request) {
     }
 
     const collection = await getTradeCollection();
+    if (!collection) {
+      return NextResponse.json(
+        { error: ASTRA_DB_MISSING_ENV_MESSAGE },
+        { status: 500 },
+      );
+    }
     const cursor = await collection.find(filter, {
       limit: Number.isNaN(limit) ? 200 : limit,
       sort: { createdAt: -1 },
@@ -97,6 +103,12 @@ export async function POST(req: Request) {
 
     const sanitizedAttachments = normalizeAttachments(attachments);
     const collection = await getTradeCollection();
+    if (!collection) {
+      return NextResponse.json(
+        { error: ASTRA_DB_MISSING_ENV_MESSAGE },
+        { status: 500 },
+      );
+    }
 
     const openTradesCursor = await collection.find({ status: 'open' }, { limit: 12 });
     const openTradeDocuments = (await openTradesCursor.toArray()) as TradeDocumentRecord[];

--- a/lib/astra.ts
+++ b/lib/astra.ts
@@ -6,20 +6,44 @@ const {
   ASTRA_DB_NAMESPACE,
 } = process.env;
 
-if (!ASTRA_DB_APPLICATION_TOKEN || !ASTRA_DB_API_ENDPOINT || !ASTRA_DB_NAMESPACE) {
-  console.warn('Astra DB environment variables are missing. Database operations will fail.');
-}
-
 export const TRADE_COLLECTION_NAME = process.env.ASTRA_DB_TRADE_COLLECTION ?? 'trades_journal_v1';
 
-export const astraDb = new AstraDB(
-  ASTRA_DB_APPLICATION_TOKEN,
-  ASTRA_DB_API_ENDPOINT,
-  ASTRA_DB_NAMESPACE,
-);
+let astraDb: AstraDB | null = null;
+let hasLoggedMissingEnv = false;
+
+const getDb = (): AstraDB | null => {
+  if (astraDb) {
+    return astraDb;
+  }
+
+  const missingVars: string[] = [];
+  if (!ASTRA_DB_APPLICATION_TOKEN) missingVars.push('ASTRA_DB_APPLICATION_TOKEN');
+  if (!ASTRA_DB_API_ENDPOINT) missingVars.push('ASTRA_DB_API_ENDPOINT');
+  if (!ASTRA_DB_NAMESPACE) missingVars.push('ASTRA_DB_NAMESPACE');
+
+  if (missingVars.length > 0) {
+    if (!hasLoggedMissingEnv) {
+      console.error(
+        `Astra DB environment variables are missing: ${missingVars.join(', ')}. Database operations are disabled.`,
+      );
+      hasLoggedMissingEnv = true;
+    }
+    return null;
+  }
+
+  astraDb = new AstraDB(ASTRA_DB_APPLICATION_TOKEN, ASTRA_DB_API_ENDPOINT, ASTRA_DB_NAMESPACE);
+  return astraDb;
+};
 
 export type TradeCollection = Awaited<ReturnType<AstraDB['collection']>>;
 
-export const getTradeCollection = async (): Promise<TradeCollection> => {
-  return astraDb.collection(TRADE_COLLECTION_NAME);
+export const getTradeCollection = async (): Promise<TradeCollection | null> => {
+  const db = getDb();
+  if (!db) {
+    return null;
+  }
+  return db.collection(TRADE_COLLECTION_NAME);
 };
+
+export const ASTRA_DB_MISSING_ENV_MESSAGE =
+  'Astra DB is not configured. Please set ASTRA_DB_APPLICATION_TOKEN, ASTRA_DB_API_ENDPOINT, and ASTRA_DB_NAMESPACE environment variables.';


### PR DESCRIPTION
## Summary
- lazily create the Astra DB client only after verifying required environment variables and reuse a shared error message
- guard each API route handler to return a clear 500 response when the database cannot be initialized

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8a5cd1c1c83318c6ee8b51e44c937