### PR TITLE
fix: force analytics api route to be dynamic

### DIFF
--- a/app/api/analytics/route.ts
+++ b/app/api/analytics/route.ts
@@ -3,6 +3,8 @@ import { ASTRA_DB_MISSING_ENV_MESSAGE, getTradeCollection } from '@/lib/astra';
 import { calculateAnalytics } from '@/lib/analytics';
 import type { TradeEntry } from '@/types/trade';
 
+export const dynamic = 'force-dynamic';
+
 export async function GET(req: NextRequest) {
   try {
     const searchParams = req.nextUrl.searchParams;


### PR DESCRIPTION
## Summary
- force the analytics API route to opt into dynamic rendering so query params can be read at runtime

## Testing
- npm run build *(fails: OPENAI_API_KEY is not set)*

------
https://chatgpt.com/codex/tasks/task_e_68c8aadce80c8331ab735d54754c3329