### PR TITLE
Improve trade logging resilience and fix neon button styling

### DIFF
--- a/app/api/trades/route.ts
+++ b/app/api/trades/route.ts
@@ -5,7 +5,9 @@ import {
   TradeAttachment,
   TradeDocument,
   TradeEntry,
+  TradeExtraction,
   TradeExtractionSchema,
+  TradeType,
 } from '@/types/trade';
 import {
   buildEmbeddingText,
@@ -25,12 +27,20 @@ const toTradeEntry = (document: TradeDocumentRecord): TradeEntry => {
   return rest;
 };
 
-const embedTrade = async (trade: TradeEntry) => {
-  const { data } = await openai.embeddings.create({
-    input: buildEmbeddingText(trade),
-    model: EMBEDDING_MODEL,
-  });
-  return data?.[0]?.embedding;
+const embedTrade = async (trade: TradeEntry): Promise<number[] | null> => {
+  if (!process.env.OPENAI_API_KEY) {
+    return null;
+  }
+  try {
+    const { data } = await openai.embeddings.create({
+      input: buildEmbeddingText(trade),
+      model: EMBEDDING_MODEL,
+    });
+    return data?.[0]?.embedding ?? null;
+  } catch (error) {
+    console.error('Failed to generate trade embedding', error);
+    return null;
+  }
 };
 
 const collectOpenTradeContext = (trades: TradeEntry[]) =>
@@ -43,6 +53,181 @@ const collectOpenTradeContext = (trades: TradeEntry[]) =>
     sentiment: trade.sentiment,
     latest_note: trade.notes.at(-1)?.text ?? '',
   }));
+
+const FALLBACK_TICKER_EXCLUSIONS = new Set([
+  'LONG',
+  'SHORT',
+  'CALL',
+  'PUT',
+  'CALLS',
+  'PUTS',
+  'OPEN',
+  'CLOSE',
+  'CLOSED',
+  'ENTRY',
+  'EXIT',
+  'STOP',
+  'LOSS',
+  'GAIN',
+  'TARGET',
+  'PNL',
+  'USD',
+  'SHARES',
+  'TRADE',
+  'NOTE',
+]);
+
+const FALLBACK_UPDATE_HINT =
+  /\b(update|add note|still in|holding|trim(?:med|ming)?|scaled|scaling|reduce|adding)\b/i;
+
+const extractNumberFromNote = (note: string, patterns: RegExp[]): number | null => {
+  for (const pattern of patterns) {
+    const match = note.match(pattern);
+    if (match) {
+      const rawValue = match[1] ?? match[2];
+      if (!rawValue) continue;
+      const normalized = rawValue.replace(/[^0-9.-]/g, '');
+      if (!normalized) continue;
+      const value = Number.parseFloat(normalized);
+      if (!Number.isNaN(value)) {
+        return value;
+      }
+    }
+  }
+  return null;
+};
+
+const extractDurationMinutes = (note: string): number | null => {
+  const minuteMatch = note.match(/(\d+(?:\.\d+)?)\s*(?:minutes|min|m)\b/i);
+  if (minuteMatch) {
+    const value = Number.parseFloat(minuteMatch[1].replace(/[^0-9.]/g, ''));
+    if (!Number.isNaN(value)) {
+      return Math.round(value);
+    }
+  }
+  const hourMatch = note.match(/(\d+(?:\.\d+)?)\s*(?:hours|hrs|hr|h)\b/i);
+  if (hourMatch) {
+    const value = Number.parseFloat(hourMatch[1].replace(/[^0-9.]/g, ''));
+    if (!Number.isNaN(value)) {
+      return Math.round(value * 60);
+    }
+  }
+  return null;
+};
+
+const detectTickerFromNote = (note: string): string | undefined => {
+  const symbolMatch = note.match(/\$([A-Za-z]{1,5})\b/);
+  if (symbolMatch) {
+    return symbolMatch[1].toUpperCase();
+  }
+  const candidates = note.toUpperCase().match(/\b[A-Z]{2,5}\b/g);
+  if (!candidates) {
+    return undefined;
+  }
+  for (const candidate of candidates) {
+    if (FALLBACK_TICKER_EXCLUSIONS.has(candidate)) continue;
+    if (/^\d+$/.test(candidate)) continue;
+    return candidate;
+  }
+  return undefined;
+};
+
+const detectTradeTypeFromNote = (note: string): TradeType => {
+  if (/\bput(s)?\b/i.test(note)) return 'put';
+  if (/\bcall(s)?\b/i.test(note)) return 'call';
+  if (/\bshort(ed|ing)?\b/i.test(note)) return 'short';
+  return 'long';
+};
+
+const detectStatusFromNote = (note: string): 'open' | 'closed' => {
+  if (/\b(close|closed|exit|exited|trimmed|stopped|stopped out|took profit|tp|sold)\b/i.test(note)) {
+    return 'closed';
+  }
+  return 'open';
+};
+
+const detectSentimentFromNote = (note: string): string | null => {
+  const mappings = [
+    { regex: /\bbearish\b|\bfearful\b|\banxious\b|\bworried\b|\bnervous\b|\bscared\b/i, value: 'bearish' },
+    { regex: /\bbullish\b|\bconfident\b|\boptimistic\b|\bexcited\b|\bpositive\b/i, value: 'bullish' },
+    { regex: /\bneutral\b|\bmeh\b|\bindifferent\b/i, value: 'neutral' },
+    { regex: /\bfrustrated\b|\bupset\b|\bangry\b|\bannoyed\b|\bdisappointed\b/i, value: 'frustrated' },
+    { regex: /\bhappy\b|\bpleased\b|\brelieved\b|\bproud\b/i, value: 'happy' },
+  ] as const;
+  for (const mapping of mappings) {
+    if (mapping.regex.test(note)) {
+      return mapping.value;
+    }
+  }
+  return null;
+};
+
+const buildFallbackExtraction = (
+  note: string,
+  tradeId: string | undefined,
+  openTrades: TradeEntry[],
+): TradeExtraction => {
+  const detectedTicker = detectTickerFromNote(note);
+  let inferredTradeId = tradeId;
+  if (!inferredTradeId && detectedTicker) {
+    const matchingOpenTrade = openTrades.find(
+      (trade) => trade.ticker === sanitizeTicker(detectedTicker),
+    );
+    if (matchingOpenTrade && FALLBACK_UPDATE_HINT.test(note)) {
+      inferredTradeId = matchingOpenTrade.trade_id;
+    }
+  }
+
+  const entryPrice = extractNumberFromNote(note, [
+    /entry(?: price)?[^0-9-]*(-?\d+(?:\.\d+)?)/i,
+    /(?:bought|buy|added|long|call)[^$0-9-]*\$?\s*(-?\d+(?:\.\d+)?)/i,
+    /@\s*\$?\s*(-?\d+(?:\.\d+)?)/,
+  ]);
+  const exitPrice = extractNumberFromNote(note, [
+    /exit(?:ed| price)?[^0-9-]*(-?\d+(?:\.\d+)?)/i,
+    /(?:sold|close(?:d)?|trim(?:med|ming)?|took profit|tp|target)[^$0-9-]*\$?\s*(-?\d+(?:\.\d+)?)/i,
+    /stop(?:ped)?[^$0-9-]*\$?\s*(-?\d+(?:\.\d+)?)/i,
+  ]);
+  const size = extractNumberFromNote(note, [
+    /(\d+(?:\.\d+)?)\s*(?:shares|contracts|lots)/i,
+    /size\s*:?\s*(\d+(?:\.\d+)?)/i,
+    /qty\s*:?\s*(\d+(?:\.\d+)?)/i,
+  ]);
+  const pnlUsd = extractNumberFromNote(note, [
+    /(?:pnl|profit|gain|loss)[^$0-9-]*\$?\s*(-?\d+(?:\.\d+)?)/i,
+    /\$(-?\d+(?:\.\d+)?)[^%a-zA-Z]*\b(?:pnl|gain|loss)/i,
+  ]);
+  const pnlPct = extractNumberFromNote(note, [/(-?\d+(?:\.\d+)?)\s*%/i]);
+  const durationMinutes = extractDurationMinutes(note);
+  const rrRatio = extractNumberFromNote(note, [
+    /(\d+(?:\.\d+)?)\s*R\b/i,
+    /R\s*[:=]\s*(\d+(?:\.\d+)?)/i,
+  ]);
+
+  const summary = note.trim().slice(0, 280) || null;
+
+  return {
+    action: inferredTradeId ? 'update' : 'create',
+    target_trade_id: inferredTradeId,
+    trade: {
+      trade_id: inferredTradeId,
+      ticker: detectedTicker,
+      trade_type: detectTradeTypeFromNote(note),
+      size: size ?? null,
+      entry_price: entryPrice ?? null,
+      exit_price: exitPrice ?? null,
+      pnl_pct: pnlPct ?? null,
+      pnl_usd: pnlUsd ?? null,
+      duration_minutes: durationMinutes ?? null,
+      rr_ratio: rrRatio ?? null,
+      sentiment: detectSentimentFromNote(note),
+      status: detectStatusFromNote(note),
+      raw_summary: summary,
+    },
+    reasoning:
+      'Fallback heuristics were applied because the AI trade extraction service was unavailable.',
+  };
+};
 
 export async function GET(req: NextRequest) {
   try {
@@ -114,43 +299,59 @@ export async function POST(req: NextRequest) {
     const openTradeDocuments = (await openTradesCursor.toArray()) as TradeDocumentRecord[];
     const openTrades = openTradeDocuments.map(toTradeEntry);
 
-    const llmPayload = {
-      note,
-      forcedTargetId: tradeId ?? null,
-      openTrades: collectOpenTradeContext(openTrades),
-      instructions:
-        'Analyse the note, decide whether to create a new trade or update an existing open trade. '
-        + 'If the user supplied forcedTargetId use it for the update. '
-        + 'Always populate missing numeric fields with null. Use minutes for duration_minutes.',
-    };
+    const resolvedTradeId = tradeId?.trim() ? tradeId.trim() : undefined;
 
-    const completion = await openai.chat.completions.create({
-      model: CHAT_MODEL,
-      temperature: 0,
-      response_format: { type: 'json_object' },
-      messages: [
-        {
-          role: 'system',
-          content:
-            'You are an assistant that extracts structured trade journal data. '
-            + 'Return JSON with shape {"action":"create|update","target_trade_id":string|null,'
-            + '"trade":{trade_id?,ticker,trade_type,size,entry_price,exit_price,pnl_pct,pnl_usd,'
-            + 'duration_minutes,rr_ratio,sentiment,status,opened_at,closed_at,raw_summary},'
-            + '"reasoning":string}. Use null for missing fields.',
-        },
-        {
-          role: 'user',
-          content: JSON.stringify(llmPayload),
-        },
-      ],
-    });
+    let extraction: TradeExtraction | null = null;
+    if (process.env.OPENAI_API_KEY) {
+      try {
+        const llmPayload = {
+          note,
+          forcedTargetId: resolvedTradeId ?? null,
+          openTrades: collectOpenTradeContext(openTrades),
+          instructions:
+            'Analyse the note, decide whether to create a new trade or update an existing open trade. '
+            + 'If the user supplied forcedTargetId use it for the update. '
+            + 'Always populate missing numeric fields with null. Use minutes for duration_minutes.',
+        };
 
-    const rawContent = completion.choices?.[0]?.message?.content ?? '{}';
-    const extraction = TradeExtractionSchema.parse(JSON.parse(rawContent));
+        const completion = await openai.chat.completions.create({
+          model: CHAT_MODEL,
+          temperature: 0,
+          response_format: { type: 'json_object' },
+          messages: [
+            {
+              role: 'system',
+              content:
+                'You are an assistant that extracts structured trade journal data. '
+                + 'Return JSON with shape {"action":"create|update","target_trade_id":string|null,'
+                + '"trade":{trade_id?,ticker,trade_type,size,entry_price,exit_price,pnl_pct,pnl_usd,'
+                + 'duration_minutes,rr_ratio,sentiment,status,opened_at,closed_at,raw_summary},'
+                + '"reasoning":string}. Use null for missing fields.',
+            },
+            {
+              role: 'user',
+              content: JSON.stringify(llmPayload),
+            },
+          ],
+        });
+
+        const rawContent = completion.choices?.[0]?.message?.content ?? '{}';
+        extraction = TradeExtractionSchema.parse(JSON.parse(rawContent));
+      } catch (error) {
+        console.error('LLM trade extraction failed, using heuristic fallback', error);
+      }
+    }
+
+    if (!extraction) {
+      extraction = TradeExtractionSchema.parse(
+        buildFallbackExtraction(note, resolvedTradeId, openTrades),
+      );
+    }
 
     const now = new Date().toISOString();
-    const action = tradeId ? 'update' : extraction.action;
-    const targetTradeId = tradeId ?? extraction.target_trade_id ?? extraction.trade.trade_id ?? null;
+    const action = resolvedTradeId ? 'update' : extraction.action;
+    const targetTradeId =
+      resolvedTradeId ?? extraction.target_trade_id ?? extraction.trade.trade_id ?? null;
 
     if (action === 'update') {
       if (!targetTradeId) {
@@ -196,12 +397,13 @@ export async function POST(req: NextRequest) {
       };
 
       const embedding = await embedTrade(updatedTrade);
+      const vectorFields = embedding ? { $vector: embedding } : {};
       await collection.updateOne(
         { document_id: targetTradeId },
         {
           $set: {
             ...updatedTrade,
-            $vector: embedding,
+            ...vectorFields,
           },
         },
       );
@@ -241,11 +443,12 @@ export async function POST(req: NextRequest) {
     };
 
     const embedding = await embedTrade(newTrade);
+    const vectorFields = embedding ? { $vector: embedding } : {};
 
     await collection.insertOne({
       document_id: trade_id,
       ...newTrade,
-      $vector: embedding,
+      ...vectorFields,
     });
 
     return NextResponse.json({

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,10 +4,14 @@
 
 :root {
   --neon: #4dd0b3;
+  --color-neon: 77 208 179;
   --neon-soft: rgba(77, 208, 179, 0.2);
   --mint: #d4fff2;
+  --color-mint: 212 255 242;
   --muted: #5f8383;
+  --color-muted: 95 131 131;
   --ink: #010607;
+  --color-ink: 1 6 7;
   --panel: rgba(6, 18, 21, 0.85);
   --panel-border: rgba(39, 90, 90, 0.4);
   --page: rgba(9, 24, 28, 0.75);
@@ -33,6 +37,10 @@ body {
 
 .text-mint {
   color: var(--mint);
+}
+
+.text-ink {
+  color: var(--ink);
 }
 
 .text-muted {

--- a/components/analytics/AnalyticsOverlay.tsx
+++ b/components/analytics/AnalyticsOverlay.tsx
@@ -52,7 +52,7 @@ export default function AnalyticsOverlay({ analytics, loading, onClose, onRefres
             </button>
             <button
               onClick={onClose}
-              className="rounded-md bg-neon/80 px-4 py-2 text-xs font-bold uppercase tracking-[0.3em] text-black transition hover:bg-neon"
+              className="rounded-md bg-neon/80 px-4 py-2 text-xs font-bold uppercase tracking-[0.3em] text-ink transition hover:bg-neon"
             >
               Close
             </button>

--- a/components/journal/NewEntryComposer.tsx
+++ b/components/journal/NewEntryComposer.tsx
@@ -183,7 +183,7 @@ export default function NewEntryComposer({ onSubmit, isProcessing }: NewEntryCom
             type="submit"
             disabled={!note.trim() || isProcessing}
             className={clsx(
-              'rounded-md bg-neon/80 px-4 py-2 text-xs font-bold uppercase tracking-[0.3em] text-black transition hover:bg-neon',
+              'rounded-md bg-neon/80 px-4 py-2 text-xs font-bold uppercase tracking-[0.3em] text-ink transition hover:bg-neon',
               (!note.trim() || isProcessing) && 'opacity-50',
             )}
           >

--- a/components/journal/SearchBar.tsx
+++ b/components/journal/SearchBar.tsx
@@ -100,7 +100,7 @@ export default function SearchBar({ onSearch, onReset, searching, activeFilters 
             type="submit"
             disabled={searching}
             className={clsx(
-              'rounded-md bg-neon/80 px-4 py-2 text-xs font-bold uppercase tracking-[0.3em] text-black transition hover:bg-neon',
+              'rounded-md bg-neon/80 px-4 py-2 text-xs font-bold uppercase tracking-[0.3em] text-ink transition hover:bg-neon',
               searching && 'opacity-50',
             )}
           >

--- a/components/journal/TradeEditor.tsx
+++ b/components/journal/TradeEditor.tsx
@@ -376,7 +376,7 @@ export default function TradeEditor({ trade, onClose, onSave, isSaving }: TradeE
             type="submit"
             disabled={isSaving}
             className={clsx(
-              'rounded-md bg-neon/80 px-5 py-2 text-xs font-bold uppercase tracking-[0.35em] text-black transition hover:bg-neon',
+              'rounded-md bg-neon/80 px-5 py-2 text-xs font-bold uppercase tracking-[0.35em] text-ink transition hover:bg-neon',
               isSaving && 'opacity-50',
             )}
           >

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,11 @@
 /** @type {import('tailwindcss').Config} */
+const withOpacityValue = (variable) => ({ opacityValue }) => {
+  if (opacityValue !== undefined) {
+    return `rgba(var(${variable}), ${opacityValue})`;
+  }
+  return `rgb(var(${variable}))`;
+};
+
 module.exports = {
   content: [
     "./components/**/*.{js,ts,jsx,tsx,mdx}",
@@ -14,6 +21,12 @@ module.exports = {
       },
       screens: {
         origin: "800px",
+      },
+      colors: {
+        neon: withOpacityValue("--color-neon"),
+        mint: withOpacityValue("--color-mint"),
+        muted: withOpacityValue("--color-muted"),
+        ink: withOpacityValue("--color-ink"),
       },
     },
   },


### PR DESCRIPTION
## Summary
- add heuristic fallback parsing for trade journal entries when OpenAI calls fail or are unavailable
- skip vector updates when embeddings cannot be generated and retain database updates
- expose the neon palette to Tailwind and ensure neon call-to-action buttons use readable text colors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8b59d70888331a3d62ea862bad95d