### PR TITLE
Fix Astra DB env variable examples

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,11 @@
+# OpenAI configuration
 OPENAI_API_KEY=REPLACE_ME
-ASTRA_DB_ID=REPLACE_ME
-ASTRA_DB_REGION=REPLACE_ME
-ASTRA_DB_APPLICATION_TOKEN=REPLACE_ME
+
+# Astra DB configuration
+# Copy the full "API Endpoint" from your database's Vector tab.
+# It looks like: https://<db_id>-<region>.apps.astra.datastax.com
+ASTRA_DB_API_ENDPOINT=https://REPLACE_ME-REPLACE_ME.apps.astra.datastax.com
+# Use the Application Token that begins with "AstraCS:"
+ASTRA_DB_APPLICATION_TOKEN=AstraCS:REPLACE_ME
+# Namespace/Keyspace inside your Astra DB (defaults to "default_keyspace")
 ASTRA_DB_NAMESPACE=default_keyspace

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Note: Before you deploying to prod, you will want to remove seed script (`npm ru
 2. Install the dependencies by running `npm install` in your terminal.
 3. Set up the following environment variables in your IDE or `.env` file:
     - `OPENAI_API_KEY`: Your API key for OpenAI
-    - `ASTRA_DB_API_ENDPOINT`: Your Astra DB vector database endpoint
+    - `ASTRA_DB_API_ENDPOINT`: Your Astra DB vector database endpoint. Copy the full **API Endpoint** from the Vector tab of your Astra DB (for example `https://<db_id>-<region>.apps.astra.datastax.com`).
     - `ASTRA_DB_APPLICATION_TOKEN`: The generated app token for your Astra database
         - To create a new token go to your database's `Connect` tab and click `Generate Token`. (your Application Token begins with `AstraCS:...`)
     - `ASTRA_DB_NAMESPACE`: (Optional) The existing Astra Namespace/Keyspace **_in a vector-enabled DB_**


### PR DESCRIPTION
## Summary
- update the sample environment file to use the Astra DB variables that the app expects
- clarify in the README how to capture the Astra DB API endpoint when configuring the project

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8f307446883318ca0a883cbba8aff