### PR TITLE
Handle missing OpenAI credentials gracefully

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -15,7 +15,7 @@ export async function POST(req: Request) {
   try {
     const { messages, useRag = true } = await req.json();
 
-    if (!process.env.OPENAI_API_KEY) {
+    if (!openai) {
       return NextResponse.json(
         {
           error:

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -50,7 +50,7 @@ export async function POST(req: Request) {
     const collection = await getTradeCollection();
     const filter = buildFilter(body.filters);
 
-    if (!collection || !process.env.OPENAI_API_KEY) {
+    if (!collection || !openai) {
       const results = searchMemoryTrades(body.query, filter, limit);
       const answer = body.includeAnswer
         ? buildMemorySearchAnswer(body.query, results)

--- a/app/api/trades/[tradeId]/route.ts
+++ b/app/api/trades/[tradeId]/route.ts
@@ -25,7 +25,7 @@ const toTradeEntry = (document: TradeEntry & { $vector?: number[]; document_id?:
 };
 
 const embed = async (trade: TradeEntry) => {
-  if (!process.env.OPENAI_API_KEY) {
+  if (!openai) {
     return null;
   }
   try {
@@ -131,7 +131,7 @@ export async function PUT(req: Request, context: { params: Params }) {
       createdAt: existing.createdAt,
     };
 
-    if (reanalyze && note && process.env.OPENAI_API_KEY) {
+    if (reanalyze && note && openai) {
       const completion = await openai.chat.completions.create({
         model: CHAT_MODEL,
         temperature: 0,

--- a/app/api/trades/route.ts
+++ b/app/api/trades/route.ts
@@ -33,7 +33,7 @@ const toTradeEntry = (document: TradeDocumentRecord): TradeEntry => {
 };
 
 const embedTrade = async (trade: TradeEntry): Promise<number[] | null> => {
-  if (!process.env.OPENAI_API_KEY) {
+  if (!openai) {
     return null;
   }
   try {
@@ -310,7 +310,7 @@ export async function POST(req: NextRequest) {
     const resolvedTradeId = tradeId?.trim() ? tradeId.trim() : undefined;
 
     let extraction: TradeExtraction | null = null;
-    if (process.env.OPENAI_API_KEY) {
+    if (openai) {
       try {
         const llmPayload = {
           note,

--- a/lib/memory-trade-store.ts
+++ b/lib/memory-trade-store.ts
@@ -82,7 +82,7 @@ const compareWithOperator = (
 const matchesFilter = (trade: TradeEntry, filter: FilterRecord): boolean => {
   return Object.entries(filter).every(([key, condition]) => {
     if (condition == null) return true;
-    const value = (trade as Record<string, unknown>)[key];
+    const value: unknown = key in trade ? trade[key as keyof TradeEntry] : undefined;
 
     if (typeof condition === 'object' && !Array.isArray(condition)) {
       const conditionRecord = condition as Record<string, unknown>;
@@ -121,8 +121,8 @@ const sortTrades = (
   const key = sortBy === 'updatedAt' ? 'updatedAt' : 'createdAt';
   const multiplier = direction === 'asc' ? 1 : -1;
   return [...trades].sort((a, b) => {
-    const left = toComparable((a as Record<string, unknown>)[key]) ?? 0;
-    const right = toComparable((b as Record<string, unknown>)[key]) ?? 0;
+    const left = toComparable(a[key]) ?? 0;
+    const right = toComparable(b[key]) ?? 0;
     if (left === right) return 0;
     return left > right ? multiplier : -multiplier;
   });

--- a/lib/openai.ts
+++ b/lib/openai.ts
@@ -3,10 +3,10 @@ import OpenAI from 'openai';
 export const EMBEDDING_MODEL = process.env.OPENAI_EMBEDDING_MODEL ?? 'text-embedding-3-large';
 export const CHAT_MODEL = process.env.OPENAI_MODEL ?? 'gpt-4o-mini';
 
-if (!process.env.OPENAI_API_KEY) {
-  console.warn('OPENAI_API_KEY is not set. API routes that rely on OpenAI will fail.');
+const apiKey = process.env.OPENAI_API_KEY;
+
+if (!apiKey) {
+  console.warn('OPENAI_API_KEY is not set. API routes that rely on OpenAI will fall back to heuristics.');
 }
 
-export const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-});
+export const openai = apiKey ? new OpenAI({ apiKey }) : null;


### PR DESCRIPTION
## Summary
- guard the shared OpenAI client so it is only instantiated when an API key is present
- update chat, search, and trade API routes to use the guarded client and fall back to heuristics when OpenAI is unavailable

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8fffbf9648331b1ee81c0d7ad201d